### PR TITLE
Handle irregular singular of cookies

### DIFF
--- a/library/shared/src/main/scala/com/hypertino/inflector/EnglishInflector.scala
+++ b/library/shared/src/main/scala/com/hypertino/inflector/EnglishInflector.scala
@@ -37,7 +37,7 @@ class EnglishInflector(val anglicizedEnglish: Boolean) extends TwoFormInflector 
       "tuna", "djinn", "mumps", "whiting", "eland", "news", "wildebeest", "elk", "pincers", "sugar") ++
     irregular(("child", "children"), ("ephemeris", "ephemerides"), ("mongoose", "mongoose"),
       ("mythos", "mythoi"), ("soliloquy", "soliloquies"), ("trilby", "trilbys"), ("genus", "genera"),
-      ("quiz", "quizzes"), ("basis", "bases"), ("slice", "slices")) ++ {
+      ("quiz", "quizzes"), ("basis", "bases"), ("slice", "slices"), ("cookie", "cookies")) ++ {
       if (anglicizedEnglish) {
         irregular(("beef", "beefs"), ("brother", "brothers"), ("cow", "cows"),
           ("genie", "genies"), ("money", "moneys"), ("octopus", "octopuses"), ("opus", "opuses"))

--- a/library/shared/src/test/scala/com/hypertino/inflector/TestEnglishInflector.scala
+++ b/library/shared/src/test/scala/com/hypertino/inflector/TestEnglishInflector.scala
@@ -40,7 +40,8 @@ class TestEnglishInflector extends FlatSpec with Matchers {
     ("pancreas", "pancreases"),
     ("todo", "todos"),
     ("status", "statuses"),
-    ("slice", "slices")
+    ("slice", "slices"),
+    ("cookie", "cookies")
   )
 
   "EnglishInflector " should " pluralize exampleWordList" in {


### PR DESCRIPTION
Looks like the rule that converts ies -> y for plural to singular causes
problems when making the word 'cookies' singular. I've added a test that
fails before my change to the EnglishInflector and passes afterward.