### PR TITLE
Each and issue6

### DIFF
--- a/library/shared/src/main/scala/com/hypertino/inflector/EnglishInflector.scala
+++ b/library/shared/src/main/scala/com/hypertino/inflector/EnglishInflector.scala
@@ -34,7 +34,7 @@ class EnglishInflector(val anglicizedEnglish: Boolean) extends TwoFormInflector 
       "headquarters", "salmon", "carp", "herpes", "scissors", "chassis", "high-jinks", "sea-bass",
       "clippers", "homework", "series", "cod", "innings", "shears", "contretemps", "jackanapes",
       "species", "corps", "mackerel", "swine", "debris", "measles", "trout", "diabetes", "mews",
-      "tuna", "djinn", "mumps", "whiting", "eland", "news", "wildebeest", "elk", "pincers", "sugar") ++
+      "tuna", "djinn", "mumps", "whiting", "eland", "news", "wildebeest", "elk", "pincers", "sugar", "each") ++
     irregular(("child", "children"), ("ephemeris", "ephemerides"), ("mongoose", "mongoose"),
       ("mythos", "mythoi"), ("soliloquy", "soliloquies"), ("trilby", "trilbys"), ("genus", "genera"),
       ("quiz", "quizzes"), ("basis", "bases"), ("slice", "slices"), ("cookie", "cookies"), ("response", "responses"), ("case", "cases")) ++ {

--- a/library/shared/src/main/scala/com/hypertino/inflector/EnglishInflector.scala
+++ b/library/shared/src/main/scala/com/hypertino/inflector/EnglishInflector.scala
@@ -37,7 +37,7 @@ class EnglishInflector(val anglicizedEnglish: Boolean) extends TwoFormInflector 
       "tuna", "djinn", "mumps", "whiting", "eland", "news", "wildebeest", "elk", "pincers", "sugar") ++
     irregular(("child", "children"), ("ephemeris", "ephemerides"), ("mongoose", "mongoose"),
       ("mythos", "mythoi"), ("soliloquy", "soliloquies"), ("trilby", "trilbys"), ("genus", "genera"),
-      ("quiz", "quizzes"), ("basis", "bases"), ("slice", "slices"), ("cookie", "cookies"), ("response", "responses")) ++ {
+      ("quiz", "quizzes"), ("basis", "bases"), ("slice", "slices"), ("cookie", "cookies"), ("response", "responses"), ("case", "cases")) ++ {
       if (anglicizedEnglish) {
         irregular(("beef", "beefs"), ("brother", "brothers"), ("cow", "cows"),
           ("genie", "genies"), ("money", "moneys"), ("octopus", "octopuses"), ("opus", "opuses"))

--- a/library/shared/src/test/scala/com/hypertino/inflector/TestEnglishInflector.scala
+++ b/library/shared/src/test/scala/com/hypertino/inflector/TestEnglishInflector.scala
@@ -42,7 +42,9 @@ class TestEnglishInflector extends FlatSpec with Matchers {
     ("status", "statuses"),
     ("slice", "slices"),
     ("cookie", "cookies"),
-    ("response", "responses")
+    ("response", "responses"),
+    ("case", "cases"),
+    ("each", "each")
   )
 
   "EnglishInflector " should " pluralize exampleWordList" in {


### PR DESCRIPTION
I saw Issue #6 and figure'd I'd fix that while I was adding in a fix for a weird pluralization I saw while using the library. 

Right now pluralizing `each` makes `eaches` which is not correct. Each isn't a word that can be pluralized, so I added it to the uncountable list in the inflector class.