### PR TITLE
Wrong singular of "Heroes"

### DIFF
--- a/library/shared/src/main/scala/com/hypertino/inflector/EnglishInflector.scala
+++ b/library/shared/src/main/scala/com/hypertino/inflector/EnglishInflector.scala
@@ -94,7 +94,7 @@ class EnglishInflector(val anglicizedEnglish: Boolean) extends TwoFormInflector 
     categoryRule(EnglishInflector.CATEGORY_O_I, "o", "os") ++
     categoryRule(EnglishInflector.CATEGORY_O_OS, "o", "os") ++
     rule("([aeiou])o$", "$1o", "([aeiou])os$", "$1os") ++
-    rule("o$", "a", "oes$", "oes") ++
+    rule("o$", "o", "oes$", "oes") ++
     rule("ulum", "ulum", "ula", "ula") ++
     categoryRule(EnglishInflector.CATEGORY_A_ATA, "", "es") ++
     rule("s$", "s", "ses$", "ses") ++

--- a/library/shared/src/test/scala/com/hypertino/inflector/TestEnglishInflector.scala
+++ b/library/shared/src/test/scala/com/hypertino/inflector/TestEnglishInflector.scala
@@ -46,7 +46,9 @@ class TestEnglishInflector extends FlatSpec with Matchers {
     ("case", "cases"),
     ("each", "each"),
     ("license", "licenses"),
-    ("day", "days")
+    ("day", "days"),
+    ("hero", "heroes"),
+    ("potato", "potatoes")
   )
 
   "EnglishInflector " should " pluralize exampleWordList" in {


### PR DESCRIPTION
Actual: English.singular("heroes") => "hera"
Expected: English.singular("heroes") => "hero"